### PR TITLE
Revert "Start adding helper methods"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ pub use metadata::*;
 pub use postprocess::*;
 pub use scene::*;
 pub use texture::*;
-pub use utils::*;
 pub use types::*;
 pub use version::*;
 
@@ -33,6 +32,5 @@ mod metadata;
 mod postprocess;
 mod scene;
 mod texture;
-mod utils;
 mod types;
 mod version;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,0 @@
-use mesh::*;
-use types::*;
-
-#[link(name = "assimp")]
-extern {
-    pub fn FindAABBTransformed(mesh: *const AiMesh, min: *mut AiVector3D, max: *mut AiVector3D, transform: *const AiMatrix4x4);
-}


### PR DESCRIPTION
This reverts commit 867edc84c3455392a975b289c6edce826576417b.

@Eljay Sorry I messed this stuff up a bit: Turns out the FindAABBTransformed method is actually only in some part of the C++ api (not sure exactly how though, can only find it in the source but not in docs).