### PR TITLE
Add cargo:rustc-link-lib=c++ for MacOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,8 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     if target.contains("gnu") {
         println!("cargo:rustc-link-lib=stdc++");
+    } else if target.contains("apple") {
+        println!("cargo:rustc-link-lib=c++");
     }
 
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
This change fixes below issue.

https://github.com/Eljay/assimp-rs/issues/16