### PR TITLE
Disable MMD for Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ fn main() {
     let dst = Config::new("assimp")
         .define("ASSIMP_BUILD_ASSIMP_TOOLS", "OFF")
         .define("ASSIMP_BUILD_TESTS", "OFF")
+        .define("ASSIMP_BUILD_MMD_IMPORTER", "OFF")
         .define("ASSIMP_INSTALL_PDB", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("CMAKE_SUPPRESS_DEVELOPER_WARNINGS", "ON")


### PR DESCRIPTION
This change make it possible to build on windows10.

If you want to keep the build targets for other OS, could you suggest how can I change the code?